### PR TITLE
fix build with DB_CXX_INCLUDE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,9 @@ check_include_file_cxx(db_cxx.h      HAVE_DB_CXX_H)
 if(NOT HAVE_DB_CXX_H)
   message(FATAL_ERROR "ERROR: unable to find Berekely DB C++ header file.")
 endif(NOT HAVE_DB_CXX_H)
+if(NOT DB_CXX_INCLUDE_PATH STREQUAL "")
+include_directories(${DB_CXX_INCLUDE_PATH})
+endif(NOT DB_CXX_INCLUDE_PATH STREQUAL "")
 
 ## OpenCL
 set(OPENCL_INCLUDE_PATH ""


### PR DESCRIPTION
CMAKE_REQUIRED_FLAGS is only used in check_include_file_cxx for the actual build include_directories needs to be used.
